### PR TITLE
Update ConsoleReader.java

### DIFF
--- a/src/main/java/jline/ConsoleReader.java
+++ b/src/main/java/jline/ConsoleReader.java
@@ -15,7 +15,7 @@ import java.util.*;
 import java.util.List;
 
 /**
- * A reader for console applications. It supports custom tab-completion,
+ * A reader for console applications. It supports custom tab-completionn
  * saveable command history, and command line editing. On some platforms,
  * platform-specific commands will need to be issued before the reader will
  * function properly. See {@link Terminal#initializeTerminal} for convenience
@@ -218,6 +218,14 @@ public class ConsoleReader implements ConsoleOperations {
                     bindings = new FileInputStream(new File(bindingFile));
                 } 
             } catch (Exception e) {
+		// Let the application handle it and give appropriate suggestions to the user
+		// instead of hitting them with a useless stacktrace or no information at all.
+		// That's the case on linux sometimes when the terminal settings change and you
+		// end up with uncomplete ConsoleReader initialization, causing features such
+		// as command completion/recalling to be disabled.
+		if (e instanceof NumberFormatException) {
+                   throw e;
+		}
                 // swallow exceptions with option debugging
                 if (debugger != null) {
                     e.printStackTrace(debugger);


### PR DESCRIPTION
I had the following exception running my application on linux, which I couldn't catch due to its swallowing by the library. Since the debug parameter is set to true by default, the user ends up with a stracktrace that doesn't help.
I figured that the error was caused by a change on my system settings and a workaround would be to export TERM=xterm-color.
I would like to catch the exception myself and give the user appropriate advice to make it work.

```
[ERROR] Failed to construct terminal; falling back to unsupported
java.lang.NumberFormatException: For input string: "0x100"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Integer.valueOf(Integer.java:766)
	at jline.internal.InfoCmp.parseInfoCmp(InfoCmp.java:59)
	at jline.UnixTerminal.parseInfoCmp(UnixTerminal.java:242)
	at jline.UnixTerminal.<init>(UnixTerminal.java:65)
	at jline.UnixTerminal.<init>(UnixTerminal.java:50)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at jline.TerminalFactory.getFlavor(TerminalFactory.java:211)
	at jline.TerminalFactory.create(TerminalFactory.java:102)
	at jline.TerminalFactory.get(TerminalFactory.java:186)
	at jline.TerminalFactory.get(TerminalFactory.java:192)
	at jline.console.ConsoleReader.<init>(ConsoleReader.java:243)
	at jline.console.ConsoleReader.<init>(ConsoleReader.java:235)
```